### PR TITLE
fix 1message: show error if it was

### DIFF
--- a/script/1message.js
+++ b/script/1message.js
@@ -47,7 +47,7 @@ var arrMSGID = parsedURL.optionalParams.filter(function(param){
 var outputMessageText = function($message, header, callback){
    echobase.decodeMessage(header, function(error, messageText){
       $message.find('.messageText').html(
-         FidoHTML.fromText(messageText)
+         FidoHTML.fromText(error || messageText)
       );
       callback();
    });


### PR DESCRIPTION
Fix jshint warning:

``` js
script/1message.js: line 48, col 49, 'error' is defined but never used
```

Show error if it was.
